### PR TITLE
docs: Create initial README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,12 @@ The workflow is straightforward:
 
 ## Workflow Overview
 
-*(This section will use a numbered list to describe the step-by-step CI/CD workflow: Define -> Slice -> Push, as per rule:styleguide:lists:20250720-001550-008).*
+`repo-slice` is designed to be the engine of a fully automated CI/CD pipeline. The typical workflow is as follows:
+
+1.  **Define**: In your main branch, create and maintain a manifest file (e.g., `roles/ai-docs-writer.allow.txt`). This file declaratively lists every file and directory that is relevant to a specific AI role.
+2.  **Slice**: A scheduled CI/CD job checks out your repository. It then runs the `repo-slice` command, pointing to your manifest file, which creates a clean, filtered directory.
+3.  **Push**: The CI/CD job forcefully pushes the contents of this newly created directory to a dedicated context branch (e.g., `context/ai-docs-writer`), overwriting its previous contents.
+4.  **Configure**: Your AI assistant (e.g., a Gemini Gem) is configured to use this specific context branch as its knowledge source, ensuring it always has the latest, most relevant information without any manual intervention.
 
 ## Getting Started
 
@@ -39,7 +44,7 @@ The workflow is straightforward:
 
 ### Basic Usage
 
-*(This section will provide a simple, self-contained code snippet showing the most common command-line invocation, as required by rule:styleguide:code-snippets:20250720-001550-010).*
+*(This section will provide a simple, self-contained code snippet showing the most common command-line invocation, as required by rule:styleguide:code-snippets).*
 
 ## Command-Line Reference
 
@@ -47,11 +52,11 @@ The workflow is straightforward:
 
 ### Arguments
 
-*(This section will use a table to detail all command-line flags, their purpose, and whether they are required, as per rule:styleguide:tables:20250720-001550-009).*
+*(This section will use a table to detail all command-line flags, their purpose, and whether they are required, as per rule:styleguide:tables).*
 
 ### Exit Codes
 
-*(This section will formally document the tool's exit codes to aid in scripting and debugging, as per rule:styleguide:formal-syntax:20250720-001550-014).*
+*(This section will formally document the tool's exit codes to aid in scripting and debugging, as per rule:styleguide:formal-syntax).*
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ The workflow is straightforward:
 
 ## Core Features
 
-*(This section will use a bulleted list to outline the key benefits of the tool, such as its declarative manifests and automation focus, as per rule:styleguide:lists:20250720-001550-008).*
+* **Declarative Manifests**: Instead of complex filter patterns, you use a simple, explicit list of files in a manifest. This is easier to read, maintain, and generate programmatically.
+* **Automation-Focused**: Designed from the ground up to be a reliable and portable tool for any CI/CD environment like GitHub Actions or GitLab CI.
+* **Branch-Ready Output**: Produces a clean directory structure ready to be committed to a new branch, unlike tools that generate a single text file for prompting.
+* **Extension Mapping**: Optionally remap file extensions during the copy process. This is useful for improving compatibility with tools that don't recognize certain extensions, such as renaming `.tsx` files to `.ts` for better LLM interpretation.
 
 ## Workflow Overview
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # repo-slice
 
-*(A concise, one-sentence summary that establishes the tool's context and purpose, as required by rule:styleguide:context:20250720-001550-007).*
+Automate the creation of streamlined, context-specific branches for your AI assistants.
 
 ## The Problem
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@ Manually creating and maintaining these separate, context-specific branches is a
 
 ## The Solution
 
-*(This section will introduce repo-slice as the purpose-built solution and briefly explain its core function).*
+`repo-slice` is a simple, automation-focused CLI tool designed to solve this problem. It acts as the engine of a CI/CD pipeline that automatically maintains streamlined branches for your AI assistants.
+
+The workflow is straightforward:
+1.  **Define**: List the files and directories for a specific AI role in a simple `allow-list.txt` manifest.
+2.  **Slice**: In a CI/CD job, `repo-slice` reads the manifest and creates a clean, filtered copy of your repository.
+3.  **Push**: The job then pushes this filtered copy to a dedicated branch (e.g., `context/gem-ui-developer`).
+4.  **Configure**: Point your AI assistant at this branch, and it will always have the latest, relevant context without any manual updates.
 
 ## Core Features
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Automate the creation of streamlined, context-specific branches for your AI assi
 
 ## The Problem
 
-*(This section will describe the core user problem: managing large repository contexts for AI assistants and the manual effort involved).*
+As a project grows, the entire codebase quickly becomes too large to use as a single context for an AI assistant like a Gemini Gem. To work effectively, these assistants, each assigned to a specific role, need a streamlined and relevant slice of the repository.
+
+Manually creating and maintaining these separate, context-specific branches is a tedious and error-prone process that needs to be repeated every time the codebase changes.
 
 ## The Solution
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
 # repo-slice
-A simple CLI for slicing a directory from a manifest file, built for CI/CD automation.
+
+*(A concise, one-sentence summary that establishes the tool's context and purpose, as required by rule:styleguide:context:20250720-001550-007).*
+
+## The Problem
+
+*(This section will describe the core user problem: managing large repository contexts for AI assistants and the manual effort involved).*
+
+## The Solution
+
+*(This section will introduce repo-slice as the purpose-built solution and briefly explain its core function).*
+
+## Core Features
+
+*(This section will use a bulleted list to outline the key benefits of the tool, such as its declarative manifests and automation focus, as per rule:styleguide:lists:20250720-001550-008).*
+
+## Workflow Overview
+
+*(This section will use a numbered list to describe the step-by-step CI/CD workflow: Define -> Slice -> Push, as per rule:styleguide:lists:20250720-001550-008).*
+
+## Getting Started
+
+*(This parent section will house the initial steps for a new user).*
+
+### Installation
+
+*(This section will contain the steps required to install the repo-slice CLI, to be filled in upon first release).*
+
+### Basic Usage
+
+*(This section will provide a simple, self-contained code snippet showing the most common command-line invocation, as required by rule:styleguide:code-snippets:20250720-001550-010).*
+
+## Command-Line Reference
+
+*(This section will serve as the formal API documentation for the tool).*
+
+### Arguments
+
+*(This section will use a table to detail all command-line flags, their purpose, and whether they are required, as per rule:styleguide:tables:20250720-001550-009).*
+
+### Exit Codes
+
+*(This section will formally document the tool's exit codes to aid in scripting and debugging, as per rule:styleguide:formal-syntax:20250720-001550-014).*
+
+## Contributing
+
+*(This section will briefly explain the project's openness to contributions and link directly to the CONTRIBUTING.md file for detailed standards and procedures).*


### PR DESCRIPTION
This pull request introduces the foundational `README.md` file for the `repo-slice` project.

Following our "documentation-first" approach, this work establishes the project's core purpose, the problem it solves, and the high-level workflow before any application code is written. It serves as the primary entry point for new users and sets the standard for project documentation.

Resolves #1.