### PR TITLE
chore: Set up CI workflow to test placeholder action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Test Action
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test_action:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run local placeholder action
+        id: test-action
+        uses: ./ # This uses the action in the current repository
+        with:
+          manifest: './test-manifest.txt'
+          source: './test-source'
+          output: './test-output'
+
+      - name: Verify action ran
+        run: echo "Action ran successfully with test inputs."


### PR DESCRIPTION
This commit introduces the initial CI workflow to "dogfood" our own action.

The workflow runs on every pull request, checking out the code and invoking the local action with test inputs. This serves as a basic harness to validate the action.yml definition and will be expanded upon as the tool's functionality is developed.

Resolves #14.