### PR TITLE
test: Add initial test for CLI argument parsing

### DIFF
--- a/cmd/repo-slice/main.go
+++ b/cmd/repo-slice/main.go
@@ -1,8 +1,22 @@
 // file: cmd/repo-slice/main.go
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+)
 
 func main() {
+	// os.Exit is not used here to allow for clean test coverage analysis.
+	// The run function will return an error that can be handled.
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+// run executes the main logic of the application based on the provided arguments.
+func run(args []string) error {
 	fmt.Println("Hello, World! This is the starting point for repo-slice.")
+	return nil
 }

--- a/cmd/repo-slice/main_test.go
+++ b/cmd/repo-slice/main_test.go
@@ -1,0 +1,10 @@
+// file: cmd/repo-slice/main_test.go
+package main
+
+import "testing"
+
+func TestRun_ArgumentParsing(t *testing.T) {
+	// This test is currently a placeholder and is expected to fail
+	// until the argument parsing logic is implemented in run().
+	t.Fatal("Test not implemented: argument parsing needs to be verified.")
+}


### PR DESCRIPTION
This commit introduces the first test case for the command-line interface, beginning the TDD cycle for argument parsing. It creates the `cmd/repo-slice/main_test.go` file with a placeholder test that will fail until the parsing logic is implemented.

A small refactor of `main.go` is included, separating the core logic into a `run` function. This makes the application's logic testable, establishing the development pattern for all subsequent features as mandated by our TDD-first engineering discipline.

Resolves #19 