### PR TITLE
feat: Implement CLI argument parsing

### DIFF
--- a/cmd/repo-slice/main.go
+++ b/cmd/repo-slice/main.go
@@ -1,8 +1,52 @@
 // file: cmd/repo-slice/main.go
 package main
 
-import "fmt"
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+// Config holds the configuration options for the repo-slice tool,
+// parsed from command-line arguments.
+type Config struct {
+	ManifestPath string
+	SourcePath   string
+	OutputPath   string
+}
 
 func main() {
-	fmt.Println("Hello, World! This is the starting point for repo-slice.")
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+// run executes the main logic of the application based on the provided arguments.
+func run(args []string) error {
+	// The config is currently unused but will be validated and used
+	// in subsequent features.
+	_, err := parseArgs(args)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// parseArgs parses the command-line arguments and returns a Config struct.
+func parseArgs(args []string) (Config, error) {
+	var cfg Config
+	fs := flag.NewFlagSet("repo-slice", flag.ContinueOnError)
+
+	fs.StringVar(&cfg.ManifestPath, "manifest", "", "Path to the manifest file (required)")
+	fs.StringVar(&cfg.SourcePath, "source", ".", "The source directory to read from")
+	fs.StringVar(&cfg.OutputPath, "output", "", "The destination directory (required)")
+
+	// This call to Parse will handle parsing the arguments and printing usage
+	// information if -h or -help is provided.
+	if err := fs.Parse(args); err != nil {
+		return Config{}, err
+	}
+
+	return cfg, nil
 }

--- a/cmd/repo-slice/main_test.go
+++ b/cmd/repo-slice/main_test.go
@@ -1,0 +1,10 @@
+// file: cmd/repo-slice/main_test.go
+package main
+
+import "testing"
+
+func TestRun_ArgumentParsing(t *testing.T) {
+	// This test is currently a placeholder and is expected to fail
+	// until the argument parsing logic is implemented in run().
+	t.Fatal("Test not implemented: argument parsing needs to be verified.")
+}

--- a/cmd/repo-slice/main_test.go
+++ b/cmd/repo-slice/main_test.go
@@ -4,7 +4,16 @@ package main
 import "testing"
 
 func TestRun_ArgumentParsing(t *testing.T) {
-	// This test is currently a placeholder and is expected to fail
-	// until the argument parsing logic is implemented in run().
-	t.Fatal("Test not implemented: argument parsing needs to be verified.")
+	// Define the test arguments.
+	args := []string{
+		"--manifest", "test-manifest.txt",
+		"--output", "test-output",
+		"--source", "test-source",
+	}
+
+	// Run the function with the test arguments.
+	// A nil error indicates successful parsing.
+	if err := run(args); err != nil {
+		t.Errorf("run() with valid arguments failed: %v", err)
+	}
 }


### PR DESCRIPTION
This pull request introduces the foundational command-line argument parsing for `repo-slice`, resolving issues #19 and #20.

It implements the core logic required to accept the `--manifest`, `--source`, and `--output` flags, as defined in the `action.yml` and `README.md` specifications.

### Key Changes
- **Argument Parsing**: The `main.go` file is updated with a `parseArgs` function that uses the standard `flag` package to process CLI arguments.
- **Testable Structure**: The logic is refactored into a testable `run` function to enable unit testing.
- **TDD Implementation**: A corresponding test case in `main_test.go` is included to validate the argument parsing functionality, ensuring the TDD cycle is completed within this PR.

This work establishes the entry point for the application and sets the stage for subsequent features like input validation and file operations.