### PR TITLE
chore: Add coverage report comments to pull requests

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -35,6 +35,7 @@ jobs:
 
   coverage-report:
     name: "Code coverage report"
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     needs: test
     permissions:
@@ -46,4 +47,4 @@ jobs:
         uses: fgrosse/go-coverage-report@v1.1.1
         with:
           coverage-artifact-name: "code-coverage-report"
-          github-baseline-workflow-ref: "main-ci.yml"
+          coverage-file-name: "coverage.txt"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -35,7 +35,6 @@ jobs:
 
   coverage-report:
     name: "Code coverage report"
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     needs: test
     permissions:
@@ -47,4 +46,4 @@ jobs:
         uses: fgrosse/go-coverage-report@v1.1.1
         with:
           coverage-artifact-name: "code-coverage-report"
-          coverage-file-name: "coverage.txt"
+          github-baseline-workflow-ref: "main-ci.yml"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -44,7 +44,8 @@ jobs:
       pull-requests: write
     steps:
       - name: Post coverage report
-        uses: fgrosse/go-coverage-report@v1.1.1
+        uses: fgrosse/go-coverage-report@v1.2.0
         with:
           coverage-artifact-name: "code-coverage-report"
           coverage-file-name: "coverage.txt"
+          github-baseline-workflow-ref: "main-ci.yml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.22'
+          go-version: '1.22.3' # Pin to the specific version from go.mod
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,22 +1,25 @@
 # file: .github/workflows/test.yml
-name: Test and Lint
+name: Test, Lint, and Coverage
 
 on:
   pull_request:
+    types: [opened, reopened, synchronize]
+  push:
     branches:
-      - main
+      - 'main'
 
 jobs:
-  test_and_lint:
+  test:
+    name: "Run tests and lint"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Go
+      - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '^1.22'
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v6
@@ -24,5 +27,27 @@ jobs:
           version: v1.59
           args: --timeout=3m
 
-      - name: Run tests
-        run: go test ./...
+      - name: Run tests and generate coverage profile
+        run: go test -v -cover -coverprofile=coverage.txt ./...
+
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-report
+          path: coverage.txt
+
+  coverage-report:
+    name: "Code coverage report"
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
+    steps:
+      - name: Post coverage report
+        uses: fgrosse/go-coverage-report@v1.1.1
+        with:
+          coverage-artifact-name: "code-coverage-report"
+          coverage-file-name: "coverage.txt"


### PR DESCRIPTION
This commit integrates the `fgrosse/go-coverage-report` GitHub Action into the CI pipeline to provide detailed test coverage analysis directly on pull requests.

The workflow is updated to a two-job process. The first job runs the linter and tests, then archives the generated `coverage.txt` file as an artifact. A second job, conditional on the event being a pull request, downloads this artifact and uses the action to post a formatted report comment.

This provides immediate, actionable feedback to developers on how their changes have impacted the test coverage of each package, reinforcing our project's commitment to quality and comprehensive testing.

Resolves #31