### PR TITLE
chore: Add coverage artifact to CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,5 +24,11 @@ jobs:
           version: v1.59
           args: --timeout=3m
 
-      - name: Run tests
-        run: go test ./...
+      - name: Run tests and generate coverage profile
+        run: go test -v -cover -coverprofile=coverage.txt ./...
+
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-report
+          path: coverage.txt


### PR DESCRIPTION
This commit adds the first stage of our code coverage reporting pipeline. The CI workflow is updated to generate a `coverage.txt` file and upload it as a `code-coverage-report` artifact on every run.

This change establishes the necessary baseline coverage artifact on the `main` branch. A subsequent pull request will introduce the second stage of the pipeline, which will consume this artifact to post detailed coverage reports on pull requests.