### PR TITLE
chore(ci): Replace coverage tool with lcov reporter

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -34,10 +34,10 @@ jobs:
           path: coverage.txt
 
       - name: Convert coverage to LCOV format
-        uses: jandelgado/gcov2lcov-action@v1.1
+        uses: jandelgado/gcov2lcov-action@v1.1.1
 
       - name: Post coverage report with annotations
-        uses: romeovs/lcov-reporter-action@v0.3.1
+        uses: romeovs/lcov-reporter-action@v0.4.0
         with:
           lcov-file: ./coverage.lcov
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -35,12 +35,9 @@ jobs:
 
       - name: Convert coverage to LCOV format
         uses: jandelgado/gcov2lcov-action@v1.1
-        with:
-          infile: coverage.out
-          outfile: coverage.lcov
 
       - name: Post coverage report with annotations
-        uses: romeovs/lcov-reporter@v0.3.1
+        uses: romeovs/lcov-reporter-action@v0.3.1
         with:
           lcov-file: ./coverage.lcov
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -33,19 +33,14 @@ jobs:
           name: code-coverage-report
           path: coverage.txt
 
-  coverage-report:
-    name: "Code coverage report"
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    needs: test
-    permissions:
-      contents: read
-      actions: read
-      pull-requests: write
-    steps:
-      - name: Post coverage report
-        uses: fgrosse/go-coverage-report@v1.2.0
+      - name: Convert coverage to LCOV format
+        uses: jandelgado/gcov2lcov-action@v1.1
         with:
-          coverage-artifact-name: "code-coverage-report"
-          coverage-file-name: "coverage.txt"
-          github-baseline-workflow-ref: "main-ci.yml"
+          infile: coverage.out
+          outfile: coverage.lcov
+
+      - name: Post coverage report with annotations
+        uses: romeovs/lcov-reporter@v0.3.1
+        with:
+          lcov-file: ./coverage.lcov
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This commit replaces the previous coverage reporting tool with a new workflow that provides more detailed, file-by-file feedback. The old tool did not clearly report the coverage status of new files, which did not meet our project's standards for clarity.

The new process uses a two-step approach:
1. It converts Go's native `coverage.out` file to the LCOV format.
2. It uses the `romeovs/lcov-reporter` action to parse the LCOV file and post a detailed report comment to the pull request.

This new workflow will provide clear, actionable coverage information, including inline annotations for uncovered lines of code.

Improves #31