### PR TITLE
docs: Add SonarCloud badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Coverage Status](https://coveralls.io/repos/github/AlienHeadwars/repo-slice/badge.svg?branch=main)](https://coveralls.io/github/AlienHeadwars/repo-slice?branch=main)
 
+[![Quality gate](https://sonarcloud.io/api/project_badges/quality_gate?project=AlienHeadWars_repo-slice)](https://sonarcloud.io/summary/new_code?id=AlienHeadWars_repo-slice)
 
 Automate the creation of streamlined, context-specific branches for your AI assistants.
 


### PR DESCRIPTION
This commit adds the SonarCloud Quality Gate status badge to the main README.md file.

The badge provides immediate, at-a-glance visibility into the project's code quality status, reinforcing our commitment to maintaining a clean and professional codebase. This aligns with the project's goal of being a high-quality example of modern engineering principles.