### PR TITLE
docs: Correct Coveralls badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # repo-slice
 
-[![Coverage Status](https://coveralls.io/repos/github/AlienHeadwars/repo-slice/badge.svg?branch=main)](https://coveralls.io/github/AlienHeadwars/repo-slice?branch=main)
-
-[![Quality gate](https://sonarcloud.io/api/project_badges/quality_gate?project=AlienHeadWars_repo-slice)](https://sonarcloud.io/summary/new_code?id=AlienHeadWars_repo-slice)
+[![Coverage Status](https://coveralls.io/repos/github/AlienHeadWars/repo-slice/badge.svg)](https://coveralls.io/github/AlienHeadWars/repo-slice) [![Quality gate](https://sonarcloud.io/api/project_badges/quality_gate?project=AlienHeadWars_repo-slice)](https://sonarcloud.io/summary/new_code?id=AlienHeadWars_repo-slice)
 
 Automate the creation of streamlined, context-specific branches for your AI assistants.
 


### PR DESCRIPTION
This commit updates the markdown for the Coveralls badge in the README.md file to point to the correct URL.

The previous badge was not displaying the coverage status correctly. This change ensures the badge is accurate and functional, providing a clear and correct indicator of the project's test coverage.

Part of #31