### PR TITLE
docs: Update SonarCloud badge style in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # repo-slice
 
-[![Coverage Status](https://coveralls.io/repos/github/AlienHeadWars/repo-slice/badge.svg)](https://coveralls.io/github/AlienHeadWars/repo-slice) [![Quality gate](https://sonarcloud.io/api/project_badges/quality_gate?project=AlienHeadWars_repo-slice)](https://sonarcloud.io/summary/new_code?id=AlienHeadWars_repo-slice)
+[![Coverage Status](https://coveralls.io/repos/github/AlienHeadWars/repo-slice/badge.svg)](https://coveralls.io/github/AlienHeadWars/repo-slice) [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=AlienHeadWars_repo-slice&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=AlienHeadWars_repo-slice)
 
 Automate the creation of streamlined, context-specific branches for your AI assistants.
 


### PR DESCRIPTION
This commit updates the SonarCloud badge in the README.md to use the "Standard badge" style, replacing the larger "Quality Gate badge".

This change is purely aesthetic, intended to create a more consistent and streamlined look with the other badges at the top of the file.

Follow up for #37