### PR TITLE
chore: Update Go version to 1.24.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.3'
+          go-version: '1.24.5'
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v6
@@ -38,3 +38,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: coverage.out
           coveralls-repo-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          

--- a/.idx/dev.nix
+++ b/.idx/dev.nix
@@ -1,22 +1,21 @@
+# file: .idx/dev.nix
 # To learn more about how to use Nix to configure your environment
 # see: https://firebase.google.com/docs/studio/customize-workspace
 { pkgs, ... }: {
   # Which nixpkgs channel to use.
-  channel = "stable-24.05"; # or "unstable"
+  channel = "unstable"; # Use the unstable channel for newer packages
 
   # Use https://search.nixos.org/packages to find packages
   packages = [
     # Add the specific Go version and linter here
-    pkgs.go_1_22
+    pkgs.go_1_24
     pkgs.golangci-lint
   ];
-
   # Sets environment variables in the workspace
   env = {};
   idx = {
     # Search for the extensions you want on https://open-vsx.org/ and use "publisher.id"
     extensions = [];
-
     # Enable previews
     previews = {
       enable = true;

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/AlienHeadwars/repo-slice
 
-go 1.22.3
+go 1.24.5


### PR DESCRIPTION
This commit updates the project's Go toolchain from version 1.22.3 to 1.24.5. This resolves issue #46.

The version has been updated consistently across the `go.mod` file, the Nix development environment configuration, and the GitHub Actions CI workflow.

Updating to a modern Go version is a crucial step for security, performance, and maintainability. This change ensures we are using the latest stable release and resolves the underlying vulnerabilities reported by Snyk in the standard library modules.