### PR TITLE
feat: Implement file extension remapping

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,10 +19,10 @@ This document outlines the development milestones to get `repo-slice` to its fir
 **Goal**: To build a fully functional and rigorously tested CLI tool using Test-Driven Development.
 
 - [x] Set up a CI pipeline to automatically run tests and a linter.
-- [ ] Write tests for and then implement CLI argument handling.
+- [x] Write tests for and then implement CLI argument handling.
 - [x] Write tests for and then implement input validation logic.
-- [ ] Write tests for and then implement the `rsync` command execution.
-- [ ] Write tests for and then implement the extension mapping feature.
+- [x] Write tests for and then implement the `rsync` command execution.
+- [x] Write tests for and then implement the extension mapping feature.
 
 ## Milestone 3: Release & GitHub Action
 

--- a/cmd/repo-slice/main.go
+++ b/cmd/repo-slice/main.go
@@ -22,10 +22,10 @@ import (
 
 // Config holds the configuration options for the repo-slice tool.
 type Config struct {
-	ManifestPath  string
-	SourcePath    string
-	OutputPath    string
-	ExtensionMap  string
+	ManifestPath string
+	SourcePath   string
+	OutputPath   string
+	ExtensionMap string
 }
 
 // FileSystem defines an interface for file system operations needed by run.
@@ -75,8 +75,8 @@ func (r *liveRemapper) ParseExtensionMap(mapStr string) (map[string]string, erro
 	return remapper.ParseExtensionMap(mapStr)
 }
 func (r *liveRemapper) RemapExtensions(dir string, extMap map[string]string) error {
-	// This concrete implementation will be created in the integration test.
-	return errors.New("not implemented") 
+	fsys := &remapper.LiveFS{}
+	return remapper.RemapExtensions(dir, extMap, fsys)
 }
 
 func main() {

--- a/cmd/repo-slice/main.go
+++ b/cmd/repo-slice/main.go
@@ -15,15 +15,17 @@ import (
 	"io"
 	"os"
 
+	"github.com/AlienHeadwars/repo-slice/internal/remapper"
 	"github.com/AlienHeadwars/repo-slice/internal/slicer"
 	"github.com/AlienHeadwars/repo-slice/internal/validate"
 )
 
 // Config holds the configuration options for the repo-slice tool.
 type Config struct {
-	ManifestPath string
-	SourcePath   string
-	OutputPath   string
+	ManifestPath  string
+	SourcePath    string
+	OutputPath    string
+	ExtensionMap  string
 }
 
 // FileSystem defines an interface for file system operations needed by run.
@@ -36,6 +38,12 @@ type FileSystem interface {
 type Slicer interface {
 	ParseManifest(r io.Reader) ([]string, error)
 	Slice(source, output string, files []string) error
+}
+
+// Remapper defines an interface for the file remapping logic.
+type Remapper interface {
+	ParseExtensionMap(mapStr string) (map[string]string, error)
+	RemapExtensions(dir string, extMap map[string]string) error
 }
 
 // liveFS is a concrete implementation of the FileSystem interface.
@@ -55,21 +63,31 @@ func (s *liveSlicer) ParseManifest(r io.Reader) ([]string, error) {
 	return slicer.ParseManifest(r)
 }
 func (s *liveSlicer) Slice(source, output string, files []string) error {
-	// Inject the concrete dependencies here.
 	executor := &slicer.CmdExecutor{}
 	filer := &slicer.LiveTempFiler{}
 	return slicer.Slice(source, output, files, executor, filer)
 }
 
+// liveRemapper is a concrete implementation of the Remapper interface.
+type liveRemapper struct{}
+
+func (r *liveRemapper) ParseExtensionMap(mapStr string) (map[string]string, error) {
+	return remapper.ParseExtensionMap(mapStr)
+}
+func (r *liveRemapper) RemapExtensions(dir string, extMap map[string]string) error {
+	// This concrete implementation will be created in the integration test.
+	return errors.New("not implemented") 
+}
+
 func main() {
-	if err := run(os.Args[1:], &liveFS{}, &liveSlicer{}); err != nil {
+	if err := run(os.Args[1:], &liveFS{}, &liveSlicer{}, &liveRemapper{}); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }
 
 // run executes the main logic of the application.
-func run(args []string, fsys FileSystem, slicer Slicer) (err error) {
+func run(args []string, fsys FileSystem, slicer Slicer, remapper Remapper) (err error) {
 	cfg, err := parseArgs(args)
 	if err != nil {
 		return err
@@ -102,6 +120,17 @@ func run(args []string, fsys FileSystem, slicer Slicer) (err error) {
 		return fmt.Errorf("failed to execute slice operation: %w", err)
 	}
 
+	// Remap extensions if a map is provided.
+	if cfg.ExtensionMap != "" {
+		extMap, err := remapper.ParseExtensionMap(cfg.ExtensionMap)
+		if err != nil {
+			return fmt.Errorf("failed to parse extension map: %w", err)
+		}
+		if err := remapper.RemapExtensions(cfg.OutputPath, extMap); err != nil {
+			return fmt.Errorf("failed to remap extensions: %w", err)
+		}
+	}
+
 	fmt.Printf("Successfully created repository slice in %s\n", cfg.OutputPath)
 	return nil
 }
@@ -111,9 +140,10 @@ func parseArgs(args []string) (Config, error) {
 	var cfg Config
 	fs := flag.NewFlagSet("repo-slice", flag.ContinueOnError)
 
-	fs.StringVar(&cfg.ManifestPath, "manifest", "", "Path to the manifest file (required)")
-	fs.StringVar(&cfg.SourcePath, "source", ".", "The source directory to read from")
-	fs.StringVar(&cfg.OutputPath, "output", "", "The destination directory (required)")
+	fs.StringVar(&cfg.ManifestPath, "manifest", "", "Path to manifest file (required)")
+	fs.StringVar(&cfg.SourcePath, "source", ".", "Source directory")
+	fs.StringVar(&cfg.OutputPath, "output", "", "Destination directory (required)")
+	fs.StringVar(&cfg.ExtensionMap, "extension-map", "", "Comma-separated list of old:new extension pairs")
 
 	if err := fs.Parse(args); err != nil {
 		return Config{}, err

--- a/cmd/repo-slice/main_test.go
+++ b/cmd/repo-slice/main_test.go
@@ -17,13 +17,9 @@ type mockFS struct {
 	validateErr error
 	openErr     error
 }
-
 func (m *mockFS) ValidateInputs(cfg validate.Config) error { return m.validateErr }
 func (m *mockFS) Open(name string) (io.ReadCloser, error) {
-	if m.openErr != nil {
-		return nil, m.openErr
-	}
-	// Return a no-op closer for the success path.
+	if m.openErr != nil { return nil, m.openErr }
 	return io.NopCloser(strings.NewReader("")), nil
 }
 
@@ -32,33 +28,45 @@ type mockSlicer struct {
 	parseErr error
 	sliceErr error
 }
-
 func (m *mockSlicer) ParseManifest(r io.Reader) ([]string, error)       { return nil, m.parseErr }
 func (m *mockSlicer) Slice(source, output string, files []string) error { return m.sliceErr }
 
+// mockRemapper is a mock implementation of the Remapper interface for testing.
+type mockRemapper struct {
+	parseErr error
+	remapErr error
+}
+func (m *mockRemapper) ParseExtensionMap(mapStr string) (map[string]string, error) { return nil, m.parseErr }
+func (m *mockRemapper) RemapExtensions(dir string, extMap map[string]string) error { return m.remapErr }
+
+
 // TestRunUnit tests the error-handling paths of the run function using mocks.
 func TestRunUnit(t *testing.T) {
-	// Dummy args for tests that get past the parsing stage.
 	validArgs := []string{"--manifest", "m.txt", "--source", "s", "--output", "o"}
+	remapArgs := []string{"--manifest", "m.txt", "--source", "s", "--output", "o", "--extension-map", "tsx:ts"}
 
 	testCases := []struct {
 		name    string
 		args    []string
 		fs      FileSystem
 		slicer  Slicer
+		remapper Remapper
 		wantErr bool
 	}{
-		{"Argument parsing fails", []string{"--bad-flag"}, &mockFS{}, &mockSlicer{}, true},
-		{"Validation fails", validArgs, &mockFS{validateErr: errors.New("validation failed")}, &mockSlicer{}, true},
-		{"File open fails", validArgs, &mockFS{openErr: errors.New("open failed")}, &mockSlicer{}, true},
-		{"Manifest parsing fails", validArgs, &mockFS{}, &mockSlicer{parseErr: errors.New("parse failed")}, true},
-		{"Slice operation fails", validArgs, &mockFS{}, &mockSlicer{sliceErr: errors.New("slice failed")}, true},
-		{"Successful run", validArgs, &mockFS{}, &mockSlicer{}, false},
+		{"Argument parsing fails", []string{"--bad-flag"}, &mockFS{}, &mockSlicer{}, &mockRemapper{}, true},
+		{"Validation fails", validArgs, &mockFS{validateErr: errors.New("validation failed")}, &mockSlicer{}, &mockRemapper{}, true},
+		{"File open fails", validArgs, &mockFS{openErr: errors.New("open failed")}, &mockSlicer{}, &mockRemapper{}, true},
+		{"Manifest parsing fails", validArgs, &mockFS{}, &mockSlicer{parseErr: errors.New("parse failed")}, &mockRemapper{}, true},
+		{"Slice operation fails", validArgs, &mockFS{}, &mockSlicer{sliceErr: errors.New("slice failed")}, &mockRemapper{}, true},
+		{"Remap parsing fails", remapArgs, &mockFS{}, &mockSlicer{}, &mockRemapper{parseErr: errors.New("remap parse failed")}, true},
+		{"Remap operation fails", remapArgs, &mockFS{}, &mockSlicer{}, &mockRemapper{remapErr: errors.New("remap op failed")}, true},
+		{"Successful run", validArgs, &mockFS{}, &mockSlicer{}, &mockRemapper{}, false},
+		{"Successful run with remap", remapArgs, &mockFS{}, &mockSlicer{}, &mockRemapper{}, false},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := run(tc.args, tc.fs, tc.slicer)
+			err := run(tc.args, tc.fs, tc.slicer, tc.remapper)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("run() error = %v, wantErr %v", err, tc.wantErr)
 			}
@@ -66,42 +74,29 @@ func TestRunUnit(t *testing.T) {
 	}
 }
 
-// TestRunIntegration is a simple end-to-end test to ensure the real
-// components are wired together correctly for the happy path.
+// TestRunIntegration is a simple end-to-end test.
 func TestRunIntegration(t *testing.T) {
 	rootDir, err := os.MkdirTemp("", "repo-slice-integration-*")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := os.RemoveAll(rootDir); err != nil {
-			t.Fatalf("failed to remove temp dir: %v", err)
-		}
-	})
+	if err != nil { t.Fatalf("failed to create temp dir: %v", err) }
+	defer os.RemoveAll(rootDir)
 
 	sourceDir := filepath.Join(rootDir, "source")
-	if err := os.Mkdir(sourceDir, 0755); err != nil {
-		t.Fatalf("failed to create source dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(sourceDir, "a.txt"), []byte("a"), 0644); err != nil {
-		t.Fatalf("failed to create a.txt: %v", err)
-	}
+	os.Mkdir(sourceDir, 0755)
+	os.WriteFile(filepath.Join(sourceDir, "component.tsx"), []byte(""), 0644)
 
 	manifestPath := filepath.Join(rootDir, "manifest.txt")
-	if err := os.WriteFile(manifestPath, []byte("a.txt"), 0644); err != nil {
-		t.Fatalf("failed to create manifest file: %v", err)
-	}
+	os.WriteFile(manifestPath, []byte("component.tsx"), 0644)
 
 	outputPath := filepath.Join(rootDir, "output")
 
-	args := []string{"--manifest", manifestPath, "--source", sourceDir, "--output", outputPath}
-	err = run(args, &liveFS{}, &liveSlicer{})
+	args := []string{"--manifest", manifestPath, "--source", sourceDir, "--output", outputPath, "--extension-map", "tsx:ts"}
+	err = run(args, &liveFS{}, &liveSlicer{}, &liveRemapper{})
 
 	if err != nil {
 		t.Fatalf("run() failed on integration test: %v", err)
 	}
 
-	if _, err := os.Stat(filepath.Join(outputPath, "a.txt")); os.IsNotExist(err) {
-		t.Error("expected file 'a.txt' was not found in the output directory")
+	if _, err := os.Stat(filepath.Join(outputPath, "component.ts")); os.IsNotExist(err) {
+		t.Error("expected file 'component.ts' was not found in the output directory")
 	}
 }

--- a/internal/remapper/remapper.go
+++ b/internal/remapper/remapper.go
@@ -1,0 +1,30 @@
+// file: internal/remapper/remapper.go
+
+// Package remapper provides functionality for renaming files in a directory
+// based on a given extension map.
+package remapper
+
+import (
+	"io/fs"
+)
+
+// FileSystem defines an interface for file system operations needed by the
+// remapper. This allows for a mock implementation in unit tests.
+type FileSystem interface {
+	WalkDir(root string, fn fs.WalkDirFunc) error
+	Rename(oldpath, newpath string) error
+}
+
+// ParseExtensionMap parses a comma-separated string of old:new pairs into a
+// map of extensions to be remapped.
+func ParseExtensionMap(mapStr string) (map[string]string, error) {
+	// TODO: Implement parsing logic.
+	return nil, nil
+}
+
+// RemapExtensions walks a directory and renames files based on the provided
+// extension map.
+func RemapExtensions(dir string, extMap map[string]string, fsys FileSystem) error {
+	// TODO: Implement remapping logic.
+	return nil
+}

--- a/internal/remapper/remapper.go
+++ b/internal/remapper/remapper.go
@@ -5,7 +5,11 @@
 package remapper
 
 import (
+	"fmt"
 	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
 )
 
 // FileSystem defines an interface for file system operations needed by the
@@ -15,16 +19,78 @@ type FileSystem interface {
 	Rename(oldpath, newpath string) error
 }
 
+// LiveFS is a concrete implementation of the FileSystem interface that uses
+// the standard library's os and filepath packages.
+type LiveFS struct{}
+
+// WalkDir walks the file tree rooted at root, calling fn for each file or
+// directory in the tree, including root.
+func (fs *LiveFS) WalkDir(root string, fn fs.WalkDirFunc) error {
+	return filepath.WalkDir(root, fn)
+}
+
+// Rename renames (moves) oldpath to newpath.
+func (fs *LiveFS) Rename(oldpath, newpath string) error {
+	return os.Rename(oldpath, newpath)
+}
+
 // ParseExtensionMap parses a comma-separated string of old:new pairs into a
 // map of extensions to be remapped.
 func ParseExtensionMap(mapStr string) (map[string]string, error) {
-	// TODO: Implement parsing logic.
-	return nil, nil
+	if mapStr == "" {
+		return map[string]string{}, nil
+	}
+
+	extMap := make(map[string]string)
+	pairs := strings.Split(mapStr, ",")
+
+	for _, pair := range pairs {
+		pair = strings.TrimSpace(pair)
+		parts := strings.Split(pair, ":")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("malformed extension map pair: %s", pair)
+		}
+
+		oldExt := strings.TrimSpace(parts[0])
+		newExt := strings.TrimSpace(parts[1])
+
+		// Ensure extensions start with a dot for consistency.
+		if !strings.HasPrefix(oldExt, ".") {
+			oldExt = "." + oldExt
+		}
+		if !strings.HasPrefix(newExt, ".") {
+			newExt = "." + newExt
+		}
+
+		extMap[oldExt] = newExt
+	}
+
+	return extMap, nil
 }
 
 // RemapExtensions walks a directory and renames files based on the provided
 // extension map.
 func RemapExtensions(dir string, extMap map[string]string, fsys FileSystem) error {
-	// TODO: Implement remapping logic.
-	return nil
+	walkFn := func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil // Skip directories.
+		}
+
+		currentExt := filepath.Ext(path)
+		newExt, shouldRemap := extMap[currentExt]
+
+		if shouldRemap {
+			base := strings.TrimSuffix(path, currentExt)
+			newPath := base + newExt
+			if err := fsys.Rename(path, newPath); err != nil {
+				return fmt.Errorf("failed to rename %s to %s: %w", path, newPath, err)
+			}
+		}
+		return nil
+	}
+
+	return fsys.WalkDir(dir, walkFn)
 }

--- a/internal/remapper/remapper_integration_test.go
+++ b/internal/remapper/remapper_integration_test.go
@@ -7,6 +7,7 @@
 package remapper
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -34,7 +35,7 @@ func TestRemapExtensions_Integration(t *testing.T) {
 	_ = os.WriteFile(filepath.Join(rootDir, "component.tsx"), []byte(""), 0644)
 	_ = os.WriteFile(filepath.Join(rootDir, "style.css"), []byte(""), 0644)
 
-	extMap, _ := ParseExtensionMap("tsx:ts")
+	extMap := map[string]string{".tsx": ".ts"}
 	fsys := &liveFS{}
 
 	// Execute the remapping.

--- a/internal/remapper/remapper_integration_test.go
+++ b/internal/remapper/remapper_integration_test.go
@@ -1,0 +1,56 @@
+//go:build integration
+
+// This file contains integration tests for the remapper package that interact
+// with the real file system. To run these tests, use the build tag 'integration':
+// go test -v ./... -tags=integration
+
+package remapper
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// liveFS is a concrete implementation of the FileSystem interface.
+type liveFS struct{}
+
+func (fs *liveFS) WalkDir(root string, fn fs.WalkDirFunc) error {
+	return filepath.WalkDir(root, fn)
+}
+
+func (fs *liveFS) Rename(oldpath, newpath string) error {
+	return os.Rename(oldpath, newpath)
+}
+
+func TestRemapExtensions_Integration(t *testing.T) {
+	// Setup a temporary directory with files to be renamed.
+	rootDir, err := os.MkdirTemp("", "remap-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(rootDir)
+
+	_ = os.WriteFile(filepath.Join(rootDir, "component.tsx"), []byte(""), 0644)
+	_ = os.WriteFile(filepath.Join(rootDir, "style.css"), []byte(""), 0644)
+
+	extMap, _ := ParseExtensionMap("tsx:ts")
+	fsys := &liveFS{}
+
+	// Execute the remapping.
+	err = RemapExtensions(rootDir, extMap, fsys)
+	if err != nil {
+		t.Fatalf("RemapExtensions() failed: %v", err)
+	}
+
+	// Assert that the files have been correctly renamed.
+	if _, err := os.Stat(filepath.Join(rootDir, "component.ts")); os.IsNotExist(err) {
+		t.Error("Expected 'component.tsx' to be renamed to 'component.ts', but it was not found.")
+	}
+	if _, err := os.Stat(filepath.Join(rootDir, "component.tsx")); !os.IsNotExist(err) {
+		t.Error("Expected 'component.tsx' to be removed after rename, but it still exists.")
+	}
+	if _, err := os.Stat(filepath.Join(rootDir, "style.css")); os.IsNotExist(err) {
+		t.Error("Expected 'style.css' to be untouched, but it was not found.")
+	}
+}

--- a/internal/remapper/remapper_test.go
+++ b/internal/remapper/remapper_test.go
@@ -6,7 +6,21 @@ import (
 	"io/fs"
 	"reflect"
 	"testing"
+	"time"
 )
+
+// mockFileInfo implements fs.FileInfo for our mock file system.
+type mockFileInfo struct {
+	name  string
+	isDir bool
+}
+
+func (m mockFileInfo) Name() string       { return m.name }
+func (m mockFileInfo) Size() int64        { return 0 }
+func (m mockFileInfo) Mode() fs.FileMode  { return 0 }
+func (m mockFileInfo) ModTime() time.Time { return time.Time{} }
+func (m mockFileInfo) IsDir() bool        { return m.isDir }
+func (m mockFileInfo) Sys() interface{}   { return nil }
 
 // mockFS is a mock implementation of the FileSystem interface for testing.
 type mockFS struct {
@@ -62,7 +76,7 @@ func TestParseExtensionMap(t *testing.T) {
 func TestRemapExtensions(t *testing.T) {
 	t.Run("renames matching file", func(t *testing.T) {
 		fsys := &mockFS{files: map[string]bool{"component.tsx": false}}
-		extMap, _ := ParseExtensionMap("tsx:ts")
+		extMap := map[string]string{".tsx": ".ts"}
 		err := RemapExtensions(".", extMap, fsys)
 		if err != nil {
 			t.Fatalf("RemapExtensions() failed: %v", err)
@@ -74,7 +88,7 @@ func TestRemapExtensions(t *testing.T) {
 
 	t.Run("ignores non-matching file", func(t *testing.T) {
 		fsys := &mockFS{files: map[string]bool{"style.css": false}}
-		extMap, _ := ParseExtensionMap("tsx:ts")
+		extMap := map[string]string{".tsx": ".ts"}
 		err := RemapExtensions(".", extMap, fsys)
 		if err != nil {
 			t.Fatalf("RemapExtensions() failed: %v", err)
@@ -89,7 +103,7 @@ func TestRemapExtensions(t *testing.T) {
 			files:     map[string]bool{"component.tsx": false},
 			renameErr: errors.New("rename failed"),
 		}
-		extMap, _ := ParseExtensionMap("tsx:ts")
+		extMap := map[string]string{".tsx": ".ts"}
 		err := RemapExtensions(".", extMap, fsys)
 		if err == nil {
 			t.Error("Expected an error from rename failure, but got nil")

--- a/internal/remapper/remapper_test.go
+++ b/internal/remapper/remapper_test.go
@@ -1,0 +1,98 @@
+// file: internal/remapper/remapper_test.go
+package remapper
+
+import (
+	"errors"
+	"io/fs"
+	"reflect"
+	"testing"
+)
+
+// mockFS is a mock implementation of the FileSystem interface for testing.
+type mockFS struct {
+	files      map[string]bool // path -> isDir
+	renameErr  error
+	renameFrom string
+	renameTo   string
+}
+
+func (m *mockFS) WalkDir(root string, fn fs.WalkDirFunc) error {
+	for path, isDir := range m.files {
+		// A simplified mock of WalkDir for testing purposes.
+		d := fs.FileInfoToDirEntry(mockFileInfo{name: path, isDir: isDir})
+		if err := fn(path, d, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *mockFS) Rename(oldpath, newpath string) error {
+	m.renameFrom = oldpath
+	m.renameTo = newpath
+	return m.renameErr
+}
+
+func TestParseExtensionMap(t *testing.T) {
+	testCases := []struct {
+		name    string
+		input   string
+		want    map[string]string
+		wantErr bool
+	}{
+		{"Valid map", "tsx:ts,mdx:md", map[string]string{".tsx": ".ts", ".mdx": ".md"}, false},
+		{"Empty map", "", map[string]string{}, false},
+		{"Whitespace handling", " tsx : ts , mdx:md ", map[string]string{".tsx": ".ts", ".mdx": ".md"}, false},
+		{"Malformed pair", "tsx:ts,mdx", nil, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseExtensionMap(tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ParseExtensionMap() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("ParseExtensionMap() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRemapExtensions(t *testing.T) {
+	t.Run("renames matching file", func(t *testing.T) {
+		fsys := &mockFS{files: map[string]bool{"component.tsx": false}}
+		extMap, _ := ParseExtensionMap("tsx:ts")
+		err := RemapExtensions(".", extMap, fsys)
+		if err != nil {
+			t.Fatalf("RemapExtensions() failed: %v", err)
+		}
+		if fsys.renameTo != "component.ts" {
+			t.Errorf("Expected rename to 'component.ts', got '%s'", fsys.renameTo)
+		}
+	})
+
+	t.Run("ignores non-matching file", func(t *testing.T) {
+		fsys := &mockFS{files: map[string]bool{"style.css": false}}
+		extMap, _ := ParseExtensionMap("tsx:ts")
+		err := RemapExtensions(".", extMap, fsys)
+		if err != nil {
+			t.Fatalf("RemapExtensions() failed: %v", err)
+		}
+		if fsys.renameTo != "" {
+			t.Errorf("Expected no rename, but got rename to '%s'", fsys.renameTo)
+		}
+	})
+
+	t.Run("handles rename error", func(t *testing.T) {
+		fsys := &mockFS{
+			files:     map[string]bool{"component.tsx": false},
+			renameErr: errors.New("rename failed"),
+		}
+		extMap, _ := ParseExtensionMap("tsx:ts")
+		err := RemapExtensions(".", extMap, fsys)
+		if err == nil {
+			t.Error("Expected an error from rename failure, but got nil")
+		}
+	})
+}


### PR DESCRIPTION
Resolves #24.

This pull request introduces the file extension remapping feature, which is the final core logic required for Milestone 2. This functionality allows users to create more effective context slices for AI tools that have better support for certain file extensions (e.g., `.ts` over `.tsx`).

### Key Changes:

* **New `--extension-map` Flag**: A new optional command-line flag, `--extension-map`, has been added. It accepts a comma-separated list of `old:new` pairs (e.g., `tsx:ts,mdx:md`).

* **New `remapper` Package**: To adhere to the Single Responsibility Principle, a new `internal/remapper` package has been created. This package encapsulates all logic for parsing the extension map string and for walking a directory to rename files.

* **Test-Driven Development**: The feature was built following our TDD process:
    * Unit tests were created to validate the map parsing logic and the file renaming logic in isolation using a mock file system.
    * An integration test was added to verify the end-to-end functionality on a real file system.

* **Refactored for Testability**: The `main` package was refactored to use dependency injection for the new remapper logic, allowing for robust and reliable unit tests of the main application's error handling.