### PR TITLE
chore(ci): Set up automated releases on merge to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+# file: .github/workflows/release.yml
+name: Release
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  tag:
+    name: "Create Git Tag"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # This permission is required to push a new tag to the repository
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create Tag
+        # This action analyzes commit messages since the last tag,
+        # determines the next semantic version, and creates a new tag.
+        id: create_tag
+        uses: anothrNick/github-tag-action@1.70.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true
+          DEFAULT_BUMP: patch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,21 @@ The `<type>` in the title must be one of the following:
 
 ### Golden Rule: Atomic Commits
 
-Commits must be small, atomic, and represent a single logical change.  Avoid large, multi-purpose commits. 
+Commits must be small, atomic, and represent a single logical change.  Avoid large, multi-purpose commits.
+
+### Automated Versioning
+
+This project uses an automated release process that creates a new version tag on every merge to `main`. The type of version bump (major, minor, or patch) is determined by special hashtags in the commit messages of a pull request.
+
+To control the version, include one of the following hashtags in the body of your commit message:
+
+* `#major`: For any breaking change that is not backward-compatible.
+* `#minor`: For any new user-facing feature (`feat:`).
+* `#patch`: For any bug fix or minor improvement (`fix:`).
+* `#none`: For any change that does not affect the user, such as documentation (`docs:`), CI/CD updates (`chore:`), or refactoring (`refactor:`).
+
+If no hashtag is provided, the version will be bumped by a `patch` release by default. If multiple commits in a PR have different hashtags, the one with the highest precedence (`major` > `minor` > `patch`) will be used.
+
 
 ## Coding Standards
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ This project is committed to a high standard of code quality and security. To en
 * **SonarCloud**: For continuous static analysis to detect bugs, vulnerabilities, and code smells.
 * **Snyk**: For scanning dependencies against a database of known open-source vulnerabilities.
 * **Dependabot**: For automatically keeping our dependencies up-to-date.
+
+## Versioning
+
+This project follows [Semantic Versioning](https://semver.org/). We use an automated release process that creates a new version tag on every merge to the `main` branch. See our [Contributing Guide](CONTRIBUTING.md#automated-versioning) for details on how commit messages influence the version number.
+
 ## Contributing
 
 We welcome contributions\! Please see our [CONTRIBUTING.md](https://www.google.com/search?q=CONTRIBUTING.md) for detailed standards and procedures.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,6 +28,7 @@ This document outlines the development milestones to get `repo-slice` to its fir
 
 **Goal**: To make the well-tested tool easily consumable by the community.
 
+- [x] Set up automated semantic versioning on merge to main.
 - Create a release workflow to automatically build and attach binaries to a GitHub Release.
 - Finalize the `action.yml` to use the released binaries.
 - Test the end-to-end GitHub Action workflow.


### PR DESCRIPTION
Resolves #54.

This pull request introduces an automated release process for the project. A new GitHub Actions workflow has been added to create and push a new semantic version tag on every merge to the `main` branch.

### Key Changes:

* **New `release.yml` Workflow**: A new workflow has been added that uses the `anothrNick/github-tag-action` to analyze commit messages and determine the next version number.
* **Updated `CONTRIBUTING.md`**: The contribution guide has been updated with a new "Automated Versioning" section. This explains how contributors can use hashtags (`#major`, `#minor`, `#patch`, `#none`) in their commit messages to control the version bump.
* **Updated `README.md` and `ROADMAP.md`**: The project's main documentation and roadmap have been updated to reflect this new capability.

This new workflow is a foundational step for Milestone 3 and makes the tool discoverable by the Go module proxy, allowing it to be installed remotely via `go install`.