### PR TITLE
docs: Correct links and placeholders in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ A commit message must consist of a title and a body, separated by a blank line.
 <A detailed explanation of the "why" behind the change. This body is
 required for all non-trivial changes.>
 
-<Signed-off-by: Author Name [author.email@dugoutsanddragons.com](mailto:author.email@dugoutsanddragons.com)>
+<Signed-off-by: Author Name <author.email@example.com>>
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To use `repo-slice`, you will need the following tools installed on your system:
 Once you have the prerequisites, you can install `repo-slice` with a single command:
 
 ```bash
-go install [github.com/AlienHeadwars/repo-slice@latest](https://github.com/AlienHeadwars/repo-slice@latest)
+go install github.com/AlienHeadwars/repo-slice@latest
 ````
 
 This will download the source code, compile it, and place the `repo-slice` executable in your Go binary path, ready to be used.
@@ -132,4 +132,4 @@ This project follows [Semantic Versioning](https://semver.org/). We use an autom
 
 ## Contributing
 
-We welcome contributions\! Please see our [CONTRIBUTING.md](https://www.google.com/search?q=CONTRIBUTING.md) for detailed standards and procedures.
+We welcome contributions! Please see our [CONTRIBUTING.md](CONTRIBUTING.md) for detailed standards and procedures.


### PR DESCRIPTION
This commit resolves issue #58 by fixing several minor errors in the project's core documentation files.

The following changes have been made:
- In README.md, the `go install` command has been corrected to remove invalid Markdown formatting from the code block.
- In README.md, the link to the contribution guide has been fixed to use the correct relative path.
- In CONTRIBUTING.md, the placeholder email in the `Signed-off-by` example has been replaced with a generic one.

These changes improve the clarity and professionalism of the documentation.

Resolves #58

Release required:
#none