### PR TITLE
fix(docs): Correct go install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To use `repo-slice`, you will need the following tools installed on your system:
 Once you have the prerequisites, you can install `repo-slice` with a single command:
 
 ```bash
-go install github.com/AlienHeadwars/repo-slice@latest
+go install github.com/AlienHeadwars/repo-slice/cmd/repo-slice@latest
 ````
 
 This will download the source code, compile it, and place the `repo-slice` executable in your Go binary path, ready to be used.


### PR DESCRIPTION
This commit corrects the `go install` command in the `README.md`.

The previous command was pointing to the module root, which does not contain a runnable `main` package. The command has been updated to point to the correct package path, `.../cmd/repo-slice`, which will allow users to successfully install the tool.

Resolves #60 
Release required: #none