### PR TITLE
docs(readme): Add note about PATH variable for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,12 @@ To use `repo-slice`, you will need the following tools installed on your system:
 Once you have the prerequisites, you can install `repo-slice` with a single command:
 
 ```bash
-go install github.com/AlienHeadwars/repo-slice/cmd/repo-slice@latest
+go install [github.com/AlienHeadwars/repo-slice/cmd/repo-slice@latest](https://github.com/AlienHeadwars/repo-slice/cmd/repo-slice@latest)
 ````
 
-This will download the source code, compile it, and place the `repo-slice` executable in your Go binary path, ready to be used.
+This will download the source code, compile it, and place the `repo-slice` executable in your Go binary path.
+
+**Note**: For the `repo-slice` command to be available in your terminal, you must ensure your Go binary path is included in your system's `PATH` environment variable. The default path is typically `~/go/bin` on Linux and macOS, and `%USERPROFILE%\go\bin` on Windows.
 
 ## Usage
 


### PR DESCRIPTION
This commit updates the "Installation" section of the `README.md` to include a note advising users to ensure their Go binary path is in their system's `PATH` environment variable.

This is a common setup issue for new users of Go, and adding this explicit instruction improves the developer experience by preventing "command not found" errors after a successful installation.

Resolves #62 
Release required: #none

Signed-off-by: alienHeadwars [bantam2781@gmail.com](mailto:bantam2781@gmail.com)