### PR TITLE
fix(ci): Pin github-tag-action to a specific commit hash

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         # This action analyzes commit messages since the last tag,
         # determines the next semantic version, and creates a new tag.
         id: create_tag
-        uses: anothrNick/github-tag-action@1.70.0
+        uses: anothrNick/github-tag-action@e528bc2b9628971ce0e6f823f3052d1dcd9d512c # Pinned to v1.7.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true


### PR DESCRIPTION
Updates the release workflow to use a specific commit hash for the `anothrNick/github-tag-action` instead of a floating version tag. This is a security best practice that ensures the executed code is immutable and resolves a security hotspot identified by SonarCloud.

This change resolves issue #72.