### PR TITLE
fix(action): Hardcode binary version to ensure stability

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,11 +46,12 @@ runs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        echo "Downloading repo-slice binary for version ${{ github.action_ref }}..."
+        VERSION="v0.0.11" # Hardcoded version for stability
+        echo "Downloading repo-slice binary for version $VERSION..."
         OS=$(echo ${{ runner.os }} | tr '[:upper:]' '[:lower:]')
         ARCH=$(echo ${{ runner.arch }} | tr '[:upper:]' '[:lower:]')
         ASSET_PATTERN="repo-slice_*_${OS}_${ARCH}.tar.gz"
-        gh release download "${{ github.action_ref }}" --pattern "$ASSET_PATTERN" --repo "$GITHUB_REPOSITORY"
+        gh release download "$VERSION" --pattern "$ASSET_PATTERN" --repo "$GITHUB_REPOSITORY"
         tar -xzf "$ASSET_PATTERN"
         chmod +x ./repo-slice
 


### PR DESCRIPTION
Hardcodes the downloaded binary version to `v0.0.11` as a temporary stability measure.

The previous approach of using `${{ github.action_ref }}` fails when users pin the action to a commit SHA, as there is no corresponding release for that hash. This change ensures the action is reliable for all users, and a separate issue has been created to track the implementation of a more dynamic version resolution strategy.