### PR TITLE
fix(action): Correct path for copying .git directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,7 +67,6 @@ runs:
         ASSET_NAME="repo-slice_${VERSION#v}_${OS_ARCH}.tar.gz"
         
         echo "Downloading asset: $ASSET_NAME"
-        # Explicitly specify the action's own repository
         gh release download "$VERSION" --pattern "$ASSET_NAME" --repo "AlienHeadWars/repo-slice"
         
         tar -xzf "$ASSET_NAME"
@@ -121,7 +120,7 @@ runs:
       shell: bash
       run: |
         # Copy the parent's git configuration to retain the remote.
-        cp -r ../.git "${{ inputs.output }}"
+        cp -r ./.git "${{ inputs.output }}"
 
     - name: Push to branch
       if: "inputs.push-branch-name != ''"


### PR DESCRIPTION
Updates the "Prepare repository for push" step to use the correct relative path (`./.git`) when copying the git configuration into the output directory.

The previous path (`../.git`) was incorrect, causing the step to fail with a "No such file or directory" error.

part of #69