### PR TITLE
fix(action): Use rsync to copy the .git directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -119,8 +119,8 @@ runs:
       if: "inputs.push-branch-name != ''"
       shell: bash
       run: |
-        # Copy the parent's git configuration to retain the remote.
-        cp -r ./.git "${{ inputs.output }}"
+        # Use rsync to copy the .git directory to handle permissions correctly.
+        rsync -a ./.git/ "${{ inputs.output }}/.git/"
 
     - name: Push to branch
       if: "inputs.push-branch-name != ''"


### PR DESCRIPTION
Replaces the `cp -r` command with `rsync -a` in the "Prepare repository for push" step.

The `cp` command was encountering "Permission denied" errors when copying the contents of the `.git` directory. Using `rsync` with the archive flag (`-a`) is more robust and handles file permissions and attributes more reliably, resolving the issue.

Part of #69