### PR TITLE
fix(action): Revert to using rsync for copying .git directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -75,7 +75,6 @@ runs:
       id: slice
       shell: bash
       run: |
-        # ... (validation and execution logic remains the same) ...
         # Step 1: Validate that exactly one manifest input is provided.
         if [ -n "${{ inputs.manifest }}" ] && [ -n "${{ inputs.manifestFile }}" ]; then
           echo "Error: Both 'manifest' and 'manifestFile' inputs cannot be used simultaneously." >&2
@@ -120,8 +119,8 @@ runs:
         # Change into the output directory, which is now its own git repository.
         cd "${{ inputs.output }}"
         
-        # Copy the parent's git configuration to retain the remote.
-        cp -r ../.git .
+        # Use rsync to copy the parent's git configuration to handle permissions correctly.
+        rsync -a ../.git/ ./.git/
         
         # Configure the git user.
         git config user.name "github-actions[bot]"


### PR DESCRIPTION
Restores the use of `rsync -a` to copy the `.git` directory into the output slice. This corrects a regression where the more fragile `cp -r` command was reintroduced.

Using `rsync` is more robust and correctly handles file permissions, preventing potential "Permission denied" errors during the push step.

Part of #69