### PR TITLE
debug(action): Add file system logging to diagnose push step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -116,6 +116,15 @@ runs:
       if: "inputs.push-branch-name != ''"
       shell: bash
       run: |
+        echo "--- Verifying Directory Contents ---"
+        echo "Root directory listing:"
+        ls -R
+        
+        echo "---"
+        echo "Output directory listing:"
+        ls -R "${{ inputs.output }}"
+        echo "------------------------------------"
+
         # Change into the output directory, which is now its own git repository.
         cd "${{ inputs.output }}"
         

--- a/action.yml
+++ b/action.yml
@@ -118,11 +118,11 @@ runs:
       run: |
         echo "--- Verifying Directory Contents ---"
         echo "Root directory listing:"
-        ls -R
+        ls -l
         
         echo "---"
         echo "Output directory listing:"
-        ls -R "${{ inputs.output }}"
+        ls -l "${{ inputs.output }}"
         echo "------------------------------------"
 
         # Change into the output directory, which is now its own git repository.


### PR DESCRIPTION
This pull request adds verbose logging to the `push-to-branch` step to help diagnose an issue where the wrong files are being committed.

### Description

When running the action against an external repository, the `git commit` step was incorrectly committing files from the root of the repository instead of the contents of the sliced `output` directory.

To investigate this, these changes introduce `ls -l` commands to log the contents of both the root and the output directory immediately before the `git` commands are executed. This will give us a clear snapshot of the file system state and help identify the root cause of the incorrect commit behavior.

The logging was initially added as a recursive `ls -R` and was subsequently refined to a non-recursive `ls -l` for better readability.