### PR TITLE
fix(action): Allow action to be used multiple times in a job

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,7 +66,7 @@ runs:
         ASSET_NAME="repo-slice_${VERSION#v}_${OS_ARCH}.tar.gz"
         
         echo "Downloading asset: $ASSET_NAME"
-        gh release download "$VERSION" --pattern "$ASSET_NAME" --repo "AlienHeadWars/repo-slice"
+        gh release download "$VERSION" --pattern "$ASSET_NAME" --repo "AlienHeadWars/repo-slice" --clobber
         
         tar -xzf "$ASSET_NAME"
         chmod +x ./repo-slice
@@ -116,15 +116,6 @@ runs:
       if: "inputs.push-branch-name != ''"
       shell: bash
       run: |
-        echo "--- Verifying Directory Contents ---"
-        echo "Root directory listing:"
-        ls -l
-        
-        echo "---"
-        echo "Output directory listing:"
-        ls -l "${{ inputs.output }}"
-        echo "------------------------------------"
-
         # Change into the output directory, which is now its own git repository.
         cd "${{ inputs.output }}"
         


### PR DESCRIPTION
Adds the `--clobber` flag to the `gh release download` command. This allows the action to overwrite existing binaries if it is run more than once in the same workflow job, resolving a file conflict error.

This change makes the action idempotent within a single job run, improving its usability in more complex workflows.

Fixes #90