### PR TITLE
refactor(action): Revert to using git-auto-commit-action for push step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -112,21 +112,17 @@ runs:
         eval "$CMD"
         echo "path=${{ inputs.output }}" >> $GITHUB_OUTPUT
 
-    - name: Push to branch
+    - name: Prepare repository for push
       if: "inputs.push-branch-name != ''"
       shell: bash
       run: |
-        # Change into the output directory, which is now its own git repository.
-        cd "${{ inputs.output }}"
-        
-        # Use rsync to copy the parent's git configuration to handle permissions correctly.
-        rsync -a ../.git/ ./.git/
-        
-        # Configure the git user.
-        git config user.name "github-actions[bot]"
-        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        
-        # Add all files, commit, and force-push.
-        git add .
-        git commit -m "${{ inputs.commit-message }}"
-        git push --force origin HEAD:${{ inputs.push-branch-name }}
+        rsync -a ./.git/ "${{ inputs.output }}/.git/"
+
+    - name: Push to branch
+      if: "inputs.push-branch-name != ''"
+      uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # Pinned to v6.0.1
+      with:
+        repository: ${{ inputs.output }}
+        commit_message: ${{ inputs.commit-message }}
+        branch: ${{ inputs.push-branch-name }}
+        push_options: '--force'


### PR DESCRIPTION
Reinstates the use of the `stefanzweifel/git-auto-commit-action` for handling the Git push operation.

The previous custom script for Git commands was introduced to debug an issue that was incorrectly attributed to the commit step. Now that the root cause has been identified as a manifest-file issue, we can revert to this simpler, more maintainable, and well-tested third-party action.

Part of resolving #69