### PR TITLE
fix(action): Download binary to a temporary directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,14 +42,20 @@ runs:
     - name: Create temporary directory for binary
       id: tempdir
       shell: bash
-      run: echo "path=$(mktemp -d)" >> $GITHUB_OUTPUT
+      run: |
+        if [ -n "${{ inputs.local-binary-path }}" ]; then
+          echo "path=${{ inputs.local-binary-path }}" >> $GITHUB_OUTPUT
+        else
+          # Create a temporary directory for the binary
+          TEMP_DIR=$(mktemp -d)
+          echo "path=$TEMP_DIR/repo-slice" >> $GITHUB_OUTPUT
+        fi
 
     - name: Download and prepare binary
       if: "inputs.local-binary-path == ''"
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
-      working-directory: ${{ steps.tempdir.outputs.path }}
       run: |
         VERSION="v0.0.21" # Hardcoded version for stability
         echo "Downloading repo-slice binary for version $VERSION..."
@@ -70,11 +76,12 @@ runs:
 
         ASSET_NAME="repo-slice_${VERSION#v}_${OS_ARCH}.tar.gz"
         
-        echo "Downloading asset: $ASSET_NAME"
-        gh release download "$VERSION" --pattern "$ASSET_NAME" --repo "AlienHeadWars/repo-slice" --clobber
+        # Download to the temporary directory
+        gh release download "$VERSION" --pattern "$ASSET_NAME" --repo "AlienHeadWars/repo-slice" --clobber -D "${{ steps.tempdir.outputs.path%/* }}"
         
-        tar -xzf "$ASSET_NAME"
-        chmod +x ./repo-slice
+        # Unpack in the temporary directory
+        tar -xzf "${{ steps.tempdir.outputs.path%/* }}/$ASSET_NAME" -C "${{ steps.tempdir.outputs.path%/* }}"
+        chmod +x "${{ steps.tempdir.outputs.path }}"
 
     - name: Run repo-slice
       id: slice
@@ -97,7 +104,7 @@ runs:
         fi
 
         # Determine which binary to use
-        BINARY_PATH="${{ steps.tempdir.outputs.path }}/repo-slice"
+        BINARY_PATH="${{ steps.tempdir.outputs.path }}"
         if [ -n "${{ inputs.local-binary-path }}" ]; then
           BINARY_PATH="${{ inputs.local-binary-path }}"
         fi
@@ -110,6 +117,7 @@ runs:
         else
           MANIFEST_PATH="${{ inputs.manifestFile }}"
         fi
+
 
         # Construct and execute the repo-slice command.
         CMD="$BINARY_PATH --manifest \"$MANIFEST_PATH\" --source \"${{ inputs.source }}\" --output \"$OUTPUT_PATH\""

--- a/action.yml
+++ b/action.yml
@@ -39,11 +39,17 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Create temporary directory for binary
+      id: tempdir
+      shell: bash
+      run: echo "path=$(mktemp -d)" >> $GITHUB_OUTPUT
+
     - name: Download and prepare binary
       if: "inputs.local-binary-path == ''"
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
+      working-directory: ${{ steps.tempdir.outputs.path }}
       run: |
         VERSION="v0.0.21" # Hardcoded version for stability
         echo "Downloading repo-slice binary for version $VERSION..."
@@ -91,7 +97,7 @@ runs:
         fi
 
         # Determine which binary to use
-        BINARY_PATH="./repo-slice"
+        BINARY_PATH="${{ steps.tempdir.outputs.path }}/repo-slice"
         if [ -n "${{ inputs.local-binary-path }}" ]; then
           BINARY_PATH="${{ inputs.local-binary-path }}"
         fi

--- a/action.yml
+++ b/action.yml
@@ -39,16 +39,16 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Create temporary directory for binary
-      id: tempdir
+    - name: Prepare binary path
+      id: binary_path
       shell: bash
       run: |
         if [ -n "${{ inputs.local-binary-path }}" ]; then
           echo "path=${{ inputs.local-binary-path }}" >> $GITHUB_OUTPUT
         else
-          # Create a temporary directory for the binary
           TEMP_DIR=$(mktemp -d)
           echo "path=$TEMP_DIR/repo-slice" >> $GITHUB_OUTPUT
+          echo "dir=$TEMP_DIR" >> $GITHUB_OUTPUT
         fi
 
     - name: Download and prepare binary
@@ -56,6 +56,7 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
+        TEMP_DIR: ${{ steps.binary_path.outputs.dir }}
       run: |
         VERSION="v0.0.21" # Hardcoded version for stability
         echo "Downloading repo-slice binary for version $VERSION..."
@@ -77,11 +78,11 @@ runs:
         ASSET_NAME="repo-slice_${VERSION#v}_${OS_ARCH}.tar.gz"
         
         # Download to the temporary directory
-        gh release download "$VERSION" --pattern "$ASSET_NAME" --repo "AlienHeadWars/repo-slice" --clobber -D "${{ steps.tempdir.outputs.path%/* }}"
-        
-        # Unpack in the temporary directory
-        tar -xzf "${{ steps.tempdir.outputs.path%/* }}/$ASSET_NAME" -C "${{ steps.tempdir.outputs.path%/* }}"
-        chmod +x "${{ steps.tempdir.outputs.path }}"
+        gh release download "$VERSION" --pattern "$ASSET_NAME" --repo "AlienHeadWars/repo-slice" --clobber -D "$TEMP_DIR"
+              
+        # Unpack in the temporary directory  
+        tar -xzf "$TEMP_DIR/$ASSET_NAME" -C "$TEMP_DIR"
+        chmod +x "$TEMP_DIR/repo-slice"
 
     - name: Run repo-slice
       id: slice
@@ -97,19 +98,19 @@ runs:
           exit 1
         fi
 
-        # Determine the output path. Use a temporary directory if not specified.
         OUTPUT_PATH="${{ inputs.output }}"
         if [ -z "$OUTPUT_PATH" ]; then
           OUTPUT_PATH=$(mktemp -d)
         fi
 
         # Determine which binary to use
-        BINARY_PATH="${{ steps.tempdir.outputs.path }}"
+        BINARY_PATH="${{ steps.binary_path.outputs.path }}"
         if [ -n "${{ inputs.local-binary-path }}" ]; then
           BINARY_PATH="${{ inputs.local-binary-path }}"
         fi
 
         # Handle the manifest input.
+
         MANIFEST_PATH=""
         if [ -n "${{ inputs.manifest }}" ]; then
           MANIFEST_PATH=$(mktemp)
@@ -118,8 +119,8 @@ runs:
           MANIFEST_PATH="${{ inputs.manifestFile }}"
         fi
 
+       # Construct and execute the repo-slice command.
 
-        # Construct and execute the repo-slice command.
         CMD="$BINARY_PATH --manifest \"$MANIFEST_PATH\" --source \"${{ inputs.source }}\" --output \"$OUTPUT_PATH\""
         if [ -n "${{ inputs.extension-map }}" ]; then
           CMD="$CMD --extension-map \"${{ inputs.extension-map }}\""

--- a/action.yml
+++ b/action.yml
@@ -119,8 +119,7 @@ runs:
           MANIFEST_PATH="${{ inputs.manifestFile }}"
         fi
 
-       # Construct and execute the repo-slice command.
-
+        # Construct and execute the repo-slice command.
         CMD="$BINARY_PATH --manifest \"$MANIFEST_PATH\" --source \"${{ inputs.source }}\" --output \"$OUTPUT_PATH\""
         if [ -n "${{ inputs.extension-map }}" ]; then
           CMD="$CMD --extension-map \"${{ inputs.extension-map }}\""


### PR DESCRIPTION
Refactors the action to download and prepare the `repo-slice` binary in
an isolated, temporary directory. This prevents the binary and its
archive from being accidentally included in the repository slice,
resolving a state pollution issue.

The temporary directory is created in a separate step and used as the
`working-directory` for the download step. The main execution step then
references the binary from this isolated location.