### PR TITLE
fix(action): Use correct path for push step with temp directories

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -119,13 +119,13 @@ runs:
       if: "inputs.push-branch-name != ''"
       shell: bash
       run: |
-        rsync -a ./.git/ "${{ inputs.output }}/.git/"
+        rsync -a ./.git/ "${{ steps.slice.outputs.path }}/.git/"
 
     - name: Push to branch
       if: "inputs.push-branch-name != ''"
       uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # Pinned to v6.0.1
       with:
-        repository: ${{ inputs.output }}
+        repository: ${{ steps.slice.outputs.path }}
         commit_message: ${{ inputs.commit-message }}
         branch: ${{ inputs.push-branch-name }}
         push_options: '--force'


### PR DESCRIPTION
Updates the "Prepare repository for push" and "Push to branch" steps to use the `steps.slice.outputs.path` context variable.

This corrects a bug where the push logic was still referencing the `inputs.output` variable, which is empty when a temporary directory is being used. This change ensures that the push step correctly targets the generated slice directory in all cases.