### PR TITLE
fix(ci): Use a PAT to allow committing to the protected main branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,16 @@ jobs:
     name: "Create and Update Version"
     runs-on: ubuntu-latest
     permissions:
-      contents: write # This permission is required to push a new tag to the repository
+      contents: write
     outputs:
       tag: ${{ steps.create_tag.outputs.new_tag }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Required for the tag action to analyze commit history
+          fetch-depth: 0
+          # Use the PAT to allow pushing to the protected main branch.
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Calculate next version (Dry Run)
         id: tag_dry_run
@@ -75,7 +77,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.5' # Should match your go.mod version
+          go-version: '1.24.5'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # Pinned to v6.0.0


### PR DESCRIPTION
Updates the release workflow to use a Personal Access Token (PAT) for the checkout step. This provides the necessary permissions for the `git-auto-commit-action` to push the automated version bump commit directly to the protected `main` branch.

This resolves the "Protected branch update failed" error.