### PR TITLE
fix(ci): Prevent recursive workflow runs on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   tag:
     name: "Create and Update Version"
+    # Add a condition to the job to prevent it from running on commits made by the bot.
+    if: "github.actor != 'github-actions[bot]'"
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Adds a condition to the `release.yml` workflow to prevent it from re-triggering itself. The workflow will now only run if the commit actor is not the `github-actions[bot]`.

This resolves an issue where the automated "version bump" commit was causing a second, unwanted workflow run, which would then fail when attempting to create a duplicate release.

Fixes issue caused in #77