### PR TITLE
fix(ci): Use correct `old_tag` output for version check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Check if a new version was created
         id: check_version
         run: |
-          if [ "${{ steps.tag_dry_run.outputs.new_tag }}" == "${{ steps.tag_dry_run.outputs.previous_tag }}" ]; then
+          if [ "${{ steps.tag_dry_run.outputs.new_tag }}" == "${{ steps.tag_dry_run.outputs.old_tag }}" ]; then
             echo "No new version created. Skipping release."
             echo "new_version_created=false" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
Updates the "Check if a new version was created" step to use the correct `old_tag` output from the `github-tag-action`, instead of the non-existent `previous_tag`.

This resolves a bug where the workflow was incorrectly proceeding with a release even when the commit message contained a `#none` directive.