### PR TITLE
feat(action): Add file count validation

### DIFF
--- a/.github/workflows/test-action-validation.yml
+++ b/.github/workflows/test-action-validation.yml
@@ -71,7 +71,9 @@ jobs:
         uses: ./
         with:
           manifest: |
-            + /test-data/**
+            # Include everything except the .git directory
+            - /.git/
+            + **
           local-binary-path: ./repo-slice-test
           max-files: '2' # Limit is 2, slice has 3 files.
         continue-on-error: true

--- a/.github/workflows/test-action-validation.yml
+++ b/.github/workflows/test-action-validation.yml
@@ -1,0 +1,39 @@
+# .github/workflows/test-action-validation.yml
+name: Test Action Validation
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+  test_file_count_validation:
+    name: "Test max-files validation"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions-go/setup-go@v5
+        with:
+          go-version: '1.24.5'
+
+      - name: Build repo-slice binary
+        run: go build -o ./repo-slice-test ./cmd/repo-slice
+
+      - name: Create a slice that will exceed the limit
+        id: slice
+        uses: ./ # Uses the action in the current repository
+        with:
+          manifest: |
+            + **
+          local-binary-path: ./repo-slice-test
+          max-files: '5' # Set a low limit that will be exceeded
+        continue-on-error: true
+
+      - name: Check failure status
+        if: steps.slice.outcome != 'failure'
+        run: |
+          echo "Error: The action should have failed due to exceeding the file count, but it succeeded."
+          exit 1

--- a/.github/workflows/test-action-validation.yml
+++ b/.github/workflows/test-action-validation.yml
@@ -7,33 +7,77 @@ on:
       - 'main'
 
 jobs:
-  test_file_count_validation:
-    name: "Test max-files validation"
+  test_file_count_pass:
+    name: "Test max-files validation (Pass)"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions-go/setup-go@v5
+        uses: actions/setup-go@v5
         with:
           go-version: '1.24.5'
 
       - name: Build repo-slice binary
         run: go build -o ./repo-slice-test ./cmd/repo-slice
 
-      - name: Create a slice that will exceed the limit
+      - name: Create test data
+        run: |
+          mkdir -p test-data/subdir
+          touch test-data/file1.txt
+          touch test-data/file2.txt
+          touch test-data/subdir/file3.txt
+
+      - name: Run repo-slice action
         id: slice
-        uses: ./ # Uses the action in the current repository
+        uses: ./
         with:
           manifest: |
-            + **
+            + /test-data/**
           local-binary-path: ./repo-slice-test
-          max-files: '5' # Set a low limit that will be exceeded
+          max-files: '5' # Limit is 5, slice has 3 files.
+
+      - name: Check success status
+        if: steps.slice.outcome != 'success'
+        run: |
+          echo "Error: The action should have succeeded but it failed."
+          exit 1
+
+  test_file_count_fail:
+    name: "Test max-files validation (Fail)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.5'
+
+      - name: Build repo-slice binary
+        run: go build -o ./repo-slice-test ./cmd/repo-slice
+
+      - name: Create test data
+        run: |
+          mkdir -p test-data/subdir
+          touch test-data/file1.txt
+          touch test-data/file2.txt
+          touch test-data/subdir/file3.txt
+
+      - name: Run repo-slice action that will exceed limit
+        id: slice
+        uses: ./
+        with:
+          manifest: |
+            + /test-data/**
+          local-binary-path: ./repo-slice-test
+          max-files: '2' # Limit is 2, slice has 3 files.
         continue-on-error: true
 
       - name: Check failure status
         if: steps.slice.outcome != 'failure'
         run: |
-          echo "Error: The action should have failed due to exceeding the file count, but it succeeded."
+          echo "Error: The action should have failed but it succeeded."
           exit 1

--- a/.github/workflows/test-action-validation.yml
+++ b/.github/workflows/test-action-validation.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           manifest: |
             + /test-data/**
+            - *
           local-binary-path: ./repo-slice-test
           max-files: '5' # Limit is 5, slice has 3 files.
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ For a complete guide on advanced features like inheriting rules from other files
 | `extension-map`| A multi-line string of `old:new` extension pairs to remap. | No | |
 | `push-branch-name`| The name of the branch to push the sliced contents to. | No | |
 | `commit-message`| The commit message to use when pushing the sliced branch. | No | `chore: Update repository slice` |
+| `max-files`| The maximum number of files allowed in the slice. | No | `5000` |
+| `max-size`| The maximum total size of the slice (e.g., `100M`). | No | `100M` |
 | `local-binary-path`| Path to a local binary. (For testing purposes). | No | |
 
 **Note**: You must provide exactly one of `manifest` or `manifest-file`.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,3 @@
-Yes, that's a great point. We should absolutely document the new validation features to make it clear to users how they work and how to configure them.
-
-The best place for this is a new "Validation" section in the `README.md`, right after the "Inputs" table.
-
-Here is the complete, updated `README.md` with the new section added.
-
-### `README.md`
-
-````markdown
 # repo-slice
 
 [![Coverage Status](https://coveralls.io/repos/github/AlienHeadWars/repo-slice/badge.svg)](https://coveralls.io/github/AlienHeadWars/repo-slice) [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=AlienHeadWars_repo-slice&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=AlienHeadWars_repo-slice)
@@ -133,17 +124,15 @@ For a complete guide on advanced features like inheriting rules from other files
 | `push-branch-name`| The name of the branch to push the sliced contents to. | No | |
 | `commit-message`| The commit message to use when pushing the sliced branch. | No | `chore: Update repository slice` |
 | `max-files`| The maximum number of files allowed in the slice. | No | `5000` |
-| `max-size`| The maximum total size of the slice (e.g., `100M`). | No | `100M` |
 | `local-binary-path`| Path to a local binary. (For testing purposes). | No | |
 
 **Note**: You must provide exactly one of `manifest` or `manifest-file`.
 
 ### Validation
 
-To prevent the creation of context branches that are too large for an AI to process, this action includes two validation steps that run after the slice is created.
+To prevent the creation of context branches that are too large for an AI to process, this action includes a validation step that runs after the slice is created.
 
   * **`max-files`**: This input sets a limit on the total number of files in the slice. If the count is exceeded, the action will fail. The default is `5000`.
-  * **`max-size`**: This input sets a limit on the total size of the slice. You can use suffixes like `K`, `M`, and `G`. If the size is exceeded, the action will fail. The default is `100M`.
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+Yes, that's a great point. We should absolutely document the new validation features to make it clear to users how they work and how to configure them.
+
+The best place for this is a new "Validation" section in the `README.md`, right after the "Inputs" table.
+
+Here is the complete, updated `README.md` with the new section added.
+
+### `README.md`
+
+````markdown
 # repo-slice
 
 [![Coverage Status](https://coveralls.io/repos/github/AlienHeadWars/repo-slice/badge.svg)](https://coveralls.io/github/AlienHeadWars/repo-slice) [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=AlienHeadWars_repo-slice&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=AlienHeadWars_repo-slice)
@@ -128,6 +137,13 @@ For a complete guide on advanced features like inheriting rules from other files
 | `local-binary-path`| Path to a local binary. (For testing purposes). | No | |
 
 **Note**: You must provide exactly one of `manifest` or `manifest-file`.
+
+### Validation
+
+To prevent the creation of context branches that are too large for an AI to process, this action includes two validation steps that run after the slice is created.
+
+  * **`max-files`**: This input sets a limit on the total number of files in the slice. If the count is exceeded, the action will fail. The default is `5000`.
+  * **`max-size`**: This input sets a limit on the total size of the slice. You can use suffixes like `K`, `M`, and `G`. If the size is exceeded, the action will fail. The default is `100M`.
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,10 @@ inputs:
   local-binary-path:
     description: 'Path to a local repo-slice binary. If set, the download step will be skipped. For testing purposes.'
     required: false
+  max-files:
+    description: 'The maximum number of files allowed in the slice. The action will fail if this is exceeded.'
+    required: false
+    default: '5000'
 
 outputs:
   slice-path:
@@ -130,13 +134,21 @@ runs:
 
         CMD="$BINARY_PATH --manifest \"$MANIFEST_PATH\" --source \"${{ inputs.source }}\" --output \"$OUTPUT_PATH\" $EXTENSION_MAP_ARG"
         
-        echo "--- Debug Info ---"
-        echo "Final command: $CMD"
-        echo "------------------"
-
         echo "Executing: $CMD"
         eval "$CMD"
         echo "path=$OUTPUT_PATH" >> $GITHUB_OUTPUT
+
+    - name: Validate slice contents
+      shell: bash
+      run: |
+        FILE_COUNT=$(find "${{ steps.slice.outputs.path }}" -type f | wc -l)
+        MAX_FILES=${{ inputs.max-files }}
+
+        echo "Slice contains $FILE_COUNT files."
+        if [ "$FILE_COUNT" -gt "$MAX_FILES" ]; then
+          echo "Error: File count ($FILE_COUNT) exceeds the maximum allowed ($MAX_FILES)." >&2
+          exit 1
+        fi
 
     - name: Prepare repository for push
       if: "inputs.push-branch-name != ''"


### PR DESCRIPTION
This pull request introduces a new validation feature to the GitHub Action to prevent the creation of overly large repository slices.

Fixes #71

### Description

A new `max-files` input has been added to the `action.yml`, which defaults to 5000. After a slice is created, a new validation step counts the number of files in the output directory and fails the workflow if this count exceeds the `max-files` limit.

This provides a critical guardrail for the action's primary use case of creating context for AI assistants, which often have a hard limit on the number of files they can process.

A new test workflow, `test-action-validation.yml`, has been added to ensure this feature works as expected.