### PR TITLE
feat(action): Add slice size validation

### DIFF
--- a/.github/workflows/test-action-validation.yml
+++ b/.github/workflows/test-action-validation.yml
@@ -72,11 +72,85 @@ jobs:
         uses: ./
         with:
           manifest: |
-            # Include everything except the .git directory
-            - /.git/
-            + **
+            + /test-data/**
+            - *
           local-binary-path: ./repo-slice-test
           max-files: '2' # Limit is 2, slice has 3 files.
+        continue-on-error: true
+
+      - name: Check failure status
+        if: steps.slice.outcome != 'failure'
+        run: |
+          echo "Error: The action should have failed but it succeeded."
+          exit 1
+
+  test_size_validation_pass:
+    name: "Test max-size validation (Pass)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.5'
+
+      - name: Build repo-slice binary
+        run: go build -o ./repo-slice-test ./cmd/repo-slice
+
+      - name: Create test data
+        run: |
+          mkdir -p test-data
+          # Create a 5KB file
+          dd if=/dev/zero of=test-data/file1.txt bs=1K count=5
+
+      - name: Run repo-slice action
+        id: slice
+        uses: ./
+        with:
+          manifest: |
+            + /test-data/**
+            - *
+          local-binary-path: ./repo-slice-test
+          max-size: '10K' # Limit is 10KB, slice is 5KB.
+
+      - name: Check success status
+        if: steps.slice.outcome != 'success'
+        run: |
+          echo "Error: The action should have succeeded but it failed."
+          exit 1
+
+  test_size_validation_fail:
+    name: "Test max-size validation (Fail)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.5'
+
+      - name: Build repo-slice binary
+        run: go build -o ./repo-slice-test ./cmd/repo-slice
+
+      - name: Create test data
+        run: |
+          mkdir -p test-data
+          # Create a 5KB file
+          dd if=/dev/zero of=test-data/file1.txt bs=1K count=5
+
+      - name: Run repo-slice action that will exceed limit
+        id: slice
+        uses: ./
+        with:
+          manifest: |
+            + /test-data/**
+            - *
+          local-binary-path: ./repo-slice-test
+          max-size: '2K' # Limit is 2KB, slice is 5KB.
         continue-on-error: true
 
       - name: Check failure status

--- a/.github/workflows/test-action-validation.yml
+++ b/.github/workflows/test-action-validation.yml
@@ -34,6 +34,7 @@ jobs:
         uses: ./
         with:
           manifest: |
+            + **/
             + /test-data/**
             - *
           local-binary-path: ./repo-slice-test
@@ -72,6 +73,7 @@ jobs:
         uses: ./
         with:
           manifest: |
+            + **/
             + /test-data/**
             - *
           local-binary-path: ./repo-slice-test
@@ -110,6 +112,7 @@ jobs:
         uses: ./
         with:
           manifest: |
+            + **/
             + /test-data/**
             - *
           local-binary-path: ./repo-slice-test
@@ -147,6 +150,7 @@ jobs:
         uses: ./
         with:
           manifest: |
+            + **/
             + /test-data/**
             - *
           local-binary-path: ./repo-slice-test

--- a/README.md
+++ b/README.md
@@ -124,15 +124,17 @@ For a complete guide on advanced features like inheriting rules from other files
 | `push-branch-name`| The name of the branch to push the sliced contents to. | No | |
 | `commit-message`| The commit message to use when pushing the sliced branch. | No | `chore: Update repository slice` |
 | `max-files`| The maximum number of files allowed in the slice. | No | `5000` |
+| `max-size`| The maximum total size of the slice (e.g., `100M`). | No | `100M` |
 | `local-binary-path`| Path to a local binary. (For testing purposes). | No | |
 
 **Note**: You must provide exactly one of `manifest` or `manifest-file`.
 
 ### Validation
 
-To prevent the creation of context branches that are too large for an AI to process, this action includes a validation step that runs after the slice is created.
+To prevent the creation of context branches that are too large for an AI to process, this action includes validation steps that run after the slice is created.
 
   * **`max-files`**: This input sets a limit on the total number of files in the slice. If the count is exceeded, the action will fail. The default is `5000`.
+  * **`max-size`**: This input sets a limit on the total size of the slice. You can use suffixes like `K`, `M`, and `G`. If the size is exceeded, the action will fail. The default is `100M`.
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: 'The maximum number of files allowed in the slice. The action will fail if this is exceeded.'
     required: false
     default: '5000'
+  max-size:
+    description: 'The maximum total size of the slice (e.g., `100M`). The action will fail if this is exceeded.'
+    required: false
+    default: '100M'
 
 outputs:
   slice-path:
@@ -147,6 +151,24 @@ runs:
         echo "Slice contains $FILE_COUNT files."
         if [ "$FILE_COUNT" -gt "$MAX_FILES" ]; then
           echo "Error: File count ($FILE_COUNT) exceeds the maximum allowed ($MAX_FILES)." >&2
+          exit 1
+        fi
+
+    - name: Validate slice size
+      shell: bash
+      run: |
+        SIZE_IN_BYTES=$(du -sb "${{ steps.slice.outputs.path }}" | cut -f1)
+        MAX_SIZE_INPUT="${{ inputs.max-size }}"
+        
+        # Convert MAX_SIZE_INPUT to bytes
+        MAX_SIZE_BYTES=$(echo "$MAX_SIZE_INPUT" | awk \
+          'BEGIN{IGNORECASE=1; K=1024; M=K*K; G=M*K; T=G*K}
+           /K/{val=$1*K} /M/{val=$1*M} /G/{val=$1*G} /T/{val=$1*T}
+           END{print val}')
+        
+        echo "Slice size is $SIZE_IN_BYTES bytes."
+        if [ "$SIZE_IN_BYTES" -gt "$MAX_SIZE_BYTES" ]; then
+          echo "Error: Slice size ($SIZE_IN_BYTES bytes) exceeds the maximum allowed ($MAX_SIZE_INPUT)." >&2
           exit 1
         fi
 


### PR DESCRIPTION
This pull request introduces a new validation feature to the GitHub Action to prevent the creation of slices that are too large.

Fixes #107

### Description

A new `max-size` input has been added to the `action.yml`, which defaults to `100M`. After a slice is created, a new validation step calculates the total size of the output directory and fails the workflow if this size exceeds the `max-size` limit.

This provides an essential guardrail for the action's primary use case of creating context for AI assistants, which have hard limits on the total size of the repository they can process.

The `test-action-validation.yml` workflow has been updated with new jobs to test both the success and failure paths for this new feature.